### PR TITLE
Convert repo to FastAPI backend

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,11 @@
+# app/database.py
+import os
+from supabase import create_client, Client
+from dotenv import load_dotenv
+
+load_dotenv()
+
+SUPABASE_URL: str = os.getenv("SUPABASE_URL") or ""
+SUPABASE_KEY: str = os.getenv("SUPABASE_KEY") or ""
+
+supabase: Client = create_client(SUPABASE_URL, SUPABASE_KEY)

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,18 @@
+# app/main.py
+import uvicorn
+from fastapi import FastAPI
+from app.routers.devops import router as devops_router
+from dotenv import load_dotenv
+
+load_dotenv()
+
+app = FastAPI(title="DevOps AI Team FastAPI", version="1.0")
+
+app.include_router(devops_router)
+
+@app.get("/")
+async def root() -> dict:
+    return {"message": "DevOps AI Team FastAPI is running!"}
+
+if __name__ == "__main__":
+    uvicorn.run("app.main:app", host="127.0.0.1", port=8000, reload=True)

--- a/app/routers/devops.py
+++ b/app/routers/devops.py
@@ -1,0 +1,108 @@
+# app/routers/devops.py
+from fastapi import APIRouter, HTTPException
+from typing import Any, Dict
+
+from app.schemas import (
+    CIConfig,
+    DockerfileConfig,
+    BuildPredictRequest,
+    StatusRequest,
+)
+from agents.github_actions_agent import GitHubActionsAgent, GitHubActionsConfig
+from agents.dockerfile_agent import DockerfileAgent, DockerfileConfig as DFConfig
+from agents.build_predictor_agent import BuildPredictorAgent, BuildPredictorConfig
+from agents.build_status_agent import BuildStatusAgent, BuildStatusConfig
+from app.database import supabase
+
+router = APIRouter(prefix="/devops", tags=["DevOps AI Agents"])
+
+@router.post("/generate-ci")
+async def generate_ci(config: CIConfig) -> Dict[str, Any]:
+    agent_cfg = GitHubActionsConfig(
+        workflow_name=config.workflow_name,
+        python_version=config.python_version,
+        run_tests=config.run_tests,
+        groq_api_endpoint=config.groq_api_endpoint,
+        groq_api_key=config.groq_api_key,
+    )
+    agent = GitHubActionsAgent(agent_cfg)
+    pipeline_yaml: str = agent.generate_pipeline()
+
+    record = {
+        "workflow_name": config.workflow_name,
+        "python_version": config.python_version,
+        "run_tests": config.run_tests,
+        "groq_api_endpoint": config.groq_api_endpoint,
+        "groq_api_key": config.groq_api_key,
+        "pipeline_yaml": pipeline_yaml,
+    }
+    result = supabase.table("ci_pipelines").insert(record).execute()
+    if result.error:
+        raise HTTPException(status_code=500, detail="Failed to save CI pipeline to DB")
+
+    return {"pipeline_yaml": pipeline_yaml, "db_id": result.data[0]["id"]}
+
+@router.post("/generate-dockerfile")
+async def generate_dockerfile(config: DockerfileConfig) -> Dict[str, Any]:
+    agent_cfg = DFConfig(
+        base_image=config.base_image,
+        expose_port=config.expose_port,
+        copy_source=config.copy_source,
+        work_dir=config.work_dir,
+        groq_api_endpoint=config.groq_api_endpoint,
+        groq_api_key=config.groq_api_key,
+    )
+    agent = DockerfileAgent(agent_cfg)
+    dockerfile_content: str = agent.generate_dockerfile()
+
+    record = {
+        "base_image": config.base_image,
+        "expose_port": config.expose_port,
+        "copy_source": config.copy_source,
+        "work_dir": config.work_dir,
+        "groq_api_endpoint": config.groq_api_endpoint,
+        "groq_api_key": config.groq_api_key,
+        "dockerfile_content": dockerfile_content,
+    }
+    result = supabase.table("dockerfiles").insert(record).execute()
+    if result.error:
+        raise HTTPException(status_code=500, detail="Failed to save Dockerfile to DB")
+
+    return {"dockerfile_content": dockerfile_content, "db_id": result.data[0]["id"]}
+
+@router.post("/predict-build")
+async def predict_build(req: BuildPredictRequest) -> Dict[str, Any]:
+    bp_cfg = BuildPredictorConfig(model=req.model, groq_api_key=req.groq_api_key)
+    agent = BuildPredictorAgent(bp_cfg)
+
+    build_data_dict = req.build_data.dict()
+    prediction: Dict[str, Any] = agent.predict_build_failure(build_data_dict)
+
+    record = {
+        "model": req.model,
+        "groq_api_key": req.groq_api_key,
+        "build_id": req.build_data.build_id,
+        "commit_hash": req.build_data.commit_hash,
+        "files_changed": req.build_data.files_changed,
+        "tests_failed": req.build_data.tests_failed,
+        "coverage": req.build_data.coverage,
+        "prediction": prediction,
+    }
+    result = supabase.table("build_predictions").insert(record).execute()
+    if result.error:
+        raise HTTPException(status_code=500, detail="Failed to save build prediction to DB")
+
+    return {"prediction": prediction, "db_id": result.data[0]["id"]}
+
+@router.post("/check-build-status")
+async def check_build_status(req: StatusRequest) -> Dict[str, Any]:
+    bs_cfg = BuildStatusConfig(image_tag=req.image_tag)
+    agent = BuildStatusAgent(bs_cfg)
+    status: str = agent.check_build_status()
+
+    record = {"image_tag": req.image_tag, "status": status}
+    result = supabase.table("build_status").insert(record).execute()
+    if result.error:
+        raise HTTPException(status_code=500, detail="Failed to save build status to DB")
+
+    return {"status": status, "db_id": result.data[0]["id"]}

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,33 @@
+# app/schemas.py
+from pydantic import BaseModel, Field
+from typing import List, Optional, Any
+
+class CIConfig(BaseModel):
+    workflow_name: str
+    python_version: str
+    run_tests: bool
+    groq_api_endpoint: str
+    groq_api_key: str
+
+class DockerfileConfig(BaseModel):
+    base_image: str
+    expose_port: int
+    copy_source: str
+    work_dir: str
+    groq_api_endpoint: str
+    groq_api_key: str
+
+class BuildData(BaseModel):
+    build_id: str
+    commit_hash: str
+    files_changed: List[str]
+    tests_failed: bool
+    coverage: float
+
+class BuildPredictRequest(BaseModel):
+    model: Optional[str] = Field(default="llama3-8b-8192")
+    groq_api_key: str
+    build_data: BuildData
+
+class StatusRequest(BaseModel):
+    image_tag: str

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
-pydantic
-pytest
-pytest-cov
-requests
+fastapi
+uvicorn
 python-dotenv
+supabase
+pydantic
+pydantic-ai
+requests
 PyGithub
 groq
-pydantic-ai
+pytest
+pytest-cov

--- a/supabase.sql
+++ b/supabase.sql
@@ -1,0 +1,44 @@
+-- supabase.sql
+
+create table if not exists ci_pipelines (
+  id bigint generated always as identity primary key,
+  created_at timestamp with time zone default now(),
+  workflow_name text not null,
+  python_version text not null,
+  run_tests boolean not null,
+  groq_api_endpoint text not null,
+  groq_api_key text not null,
+  pipeline_yaml text not null
+);
+
+create table if not exists dockerfiles (
+  id bigint generated always as identity primary key,
+  created_at timestamp with time zone default now(),
+  base_image text not null,
+  expose_port integer not null,
+  copy_source text not null,
+  work_dir text not null,
+  groq_api_endpoint text not null,
+  groq_api_key text not null,
+  dockerfile_content text not null
+);
+
+create table if not exists build_predictions (
+  id bigint generated always as identity primary key,
+  created_at timestamp with time zone default now(),
+  model text not null,
+  groq_api_key text not null,
+  build_id text not null,
+  commit_hash text not null,
+  files_changed text[] not null,
+  tests_failed boolean not null,
+  coverage double precision not null,
+  prediction jsonb not null
+);
+
+create table if not exists build_status (
+  id bigint generated always as identity primary key,
+  created_at timestamp with time zone default now(),
+  image_tag text not null,
+  status text not null
+);


### PR DESCRIPTION
## Summary
- restructure project into FastAPI app folder
- add database connection via Supabase
- create schemas and router for agents
- add SQL schema script
- add requirements list for FastAPI project
- include missing pydantic-ai dependency

## Testing
- `pip install -r requirements.txt`
- `uvicorn app.main:app --reload` *(fails on DB operations: 403 Forbidden)*
- `curl -s http://127.0.0.1:8000/`
- `pytest --cov=app`


------
https://chatgpt.com/codex/tasks/task_e_684335bd03948331a457500e48ce1f90