### PR TITLE
feat: add training workflow APIs, in-memory orchestration, docs, tests, and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+- describe what changed and why
+- call out user-visible behavior changes
+- include risk level and rollback approach
+
+## Scope
+- [ ] backend
+- [ ] frontend
+- [ ] docs
+- [ ] infra/ci
+
+## Validation
+- include exact commands and outcomes
+- include negative/failure-path tests if applicable
+
+## Security & Reliability Checklist
+- [ ] input validation updated for new API surfaces
+- [ ] authz/authn impact reviewed
+- [ ] error handling and logging paths covered
+- [ ] observability updated (health/metrics/logging)
+- [ ] rollback strategy documented
+
+## Deployment Notes
+- environment/config changes
+- migration or data backfill notes
+- post-deploy verification steps

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Production-ready platform combining FastAPI agents with a modern React control p
 - **Tooling**: Makefile targets, Dockerfiles for API/UI, Docker Compose for local orchestration
 - **Observability**: `/healthz`, `/readyz`, `/metrics` (Prometheus), request IDs on every response, structured JSON logs
 
+## Planning Documents
+- Product Definition (Brief + PRD): `docs/product-definition-prd.md`
+- Architecture Design Draft (Phase 3 / MVP): `docs/architecture-draft.md`
+
 ## Requirements
 - Python 3.12+
 - Node.js 20+
@@ -86,6 +90,9 @@ The API image exposes port `8000`; the UI image serves static assets via NGINX o
 - `POST /devops/predict-build` → `{ prediction, db_id }`
 - `POST /devops/check-build-status` → `{ status, db_id }`
 - `GET /healthz` / `GET /readyz` for monitoring probes
+- `GET /training/lifecycle` and `GET /training/modules` for learner content
+- `POST /training/plans` and `POST /training/plans/{plan_id}/execute` for workflow simulation
+- `POST /training/runs/{run_id}/approval` for approval-gated progression
 
 ## Production Notes
 - Configure secrets via environment variables or secret stores; the UI never persists API keys.

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from .config import get_settings
 from .logging_config import configure_logging
 from .observability import MetricsMiddleware, RequestIDMiddleware, metrics_endpoint
 from .routers.devops import router as devops_router
+from .routers.training import router as training_router
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
@@ -74,6 +75,7 @@ async def readyz() -> Dict[str, str]:
 
 
 app.include_router(devops_router)
+app.include_router(training_router)
 app.add_api_route("/metrics", metrics_endpoint, methods=["GET"], include_in_schema=False)
 
 

--- a/app/routers/training.py
+++ b/app/routers/training.py
@@ -1,0 +1,129 @@
+"""Training + orchestration simulation routes for DevOps learner workflows."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, HTTPException, status
+
+from app.schemas import (
+    ApprovalRequest,
+    LifecycleStage,
+    PlanCreateRequest,
+    PlanCreateResponse,
+    TrainingModule,
+    WorkflowRunResponse,
+)
+from app.services.workflow_service import workflow_service
+
+router = APIRouter(prefix="/training", tags=["Training"])
+
+LIFECYCLE_STAGES: List[LifecycleStage] = [
+    LifecycleStage(id="intake", label="Intake", description="Collect goals, constraints, and context", order=1),
+    LifecycleStage(id="plan", label="Plan", description="Build validated execution graph", order=2),
+    LifecycleStage(id="develop", label="Develop", description="Implement and review code changes", order=3),
+    LifecycleStage(id="cicd", label="CI/CD", description="Validate, package, and release safely", order=4),
+    LifecycleStage(id="observe", label="Observe", description="Monitor SLOs, logs, metrics, traces", order=5),
+    LifecycleStage(id="improve", label="Improve", description="Run postmortems and iterate", order=6),
+]
+
+TRAINING_MODULES: List[TrainingModule] = [
+    TrainingModule(
+        id="m1",
+        title="From Requirement to Release Plan",
+        phase="Plan",
+        duration_minutes=25,
+        objective="Transform ambiguous requirements into risk-aware executable tasks.",
+    ),
+    TrainingModule(
+        id="m2",
+        title="CI Pipeline Reliability Fundamentals",
+        phase="CI/CD",
+        duration_minutes=30,
+        objective="Build deterministic lint/test/build/scan gates with rollback-aware releases.",
+    ),
+    TrainingModule(
+        id="m3",
+        title="Incident Triage and Fast Recovery",
+        phase="Observe",
+        duration_minutes=20,
+        objective="Practice response flow: detect, diagnose, mitigate, and document RCA.",
+    ),
+]
+
+
+def _serialize_run(run: Any) -> Dict[str, Any]:
+    return {
+        "run_id": run.id,
+        "plan_id": run.plan_id,
+        "status": run.status,
+        "tasks": [
+            {
+                "id": task.id,
+                "title": task.title,
+                "phase": task.phase,
+                "risk_level": task.risk_level,
+                "status": task.status,
+                "rationale": task.rationale,
+            }
+            for task in run.tasks
+        ],
+        "audit_events": run.audit_events,
+    }
+
+
+@router.get("/lifecycle", response_model=List[LifecycleStage])
+async def get_lifecycle() -> List[LifecycleStage]:
+    return LIFECYCLE_STAGES
+
+
+@router.get("/modules", response_model=List[TrainingModule])
+async def list_modules() -> List[TrainingModule]:
+    return TRAINING_MODULES
+
+
+@router.post("/plans", response_model=PlanCreateResponse, status_code=status.HTTP_201_CREATED)
+async def create_plan(payload: PlanCreateRequest) -> PlanCreateResponse:
+    plan = workflow_service.create_plan(
+        workspace_id=payload.workspace_id,
+        title=payload.title,
+        objective=payload.objective,
+        tasks=[task.model_dump() for task in payload.tasks],
+    )
+    return PlanCreateResponse(plan_id=plan.id, status="draft")
+
+
+@router.post("/plans/{plan_id}/execute", response_model=WorkflowRunResponse)
+async def execute_plan(plan_id: str) -> WorkflowRunResponse:
+    try:
+        run = workflow_service.execute_plan(plan_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Plan not found") from exc
+
+    return WorkflowRunResponse(**_serialize_run(run))
+
+
+@router.get("/runs/{run_id}", response_model=WorkflowRunResponse)
+async def get_run(run_id: str) -> WorkflowRunResponse:
+    try:
+        run = workflow_service.get_run(run_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Run not found") from exc
+
+    return WorkflowRunResponse(**_serialize_run(run))
+
+
+@router.post("/runs/{run_id}/approval", response_model=WorkflowRunResponse)
+async def resolve_approval(run_id: str, payload: ApprovalRequest) -> WorkflowRunResponse:
+    try:
+        run = workflow_service.submit_approval(
+            run_id=run_id,
+            task_id=payload.task_id,
+            decision=payload.decision,
+            reason=payload.reason,
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Run or task not found") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Task not awaiting approval") from exc
+
+    return WorkflowRunResponse(**_serialize_run(run))

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -54,3 +54,60 @@ class BuildPredictRequest(BaseModel):
 
 class StatusRequest(BaseModel):
     image_tag: str = Field(..., min_length=1)
+
+
+class TrainingModule(BaseModel):
+    id: str
+    title: str
+    phase: str
+    duration_minutes: int
+    objective: str
+
+
+class LifecycleStage(BaseModel):
+    id: str
+    label: str
+    description: str
+    order: int
+
+
+class PlanTaskInput(BaseModel):
+    title: str = Field(..., min_length=3, max_length=120)
+    phase: str = Field(..., min_length=2, max_length=60)
+    risk_level: str = Field(..., pattern=r"^(low|medium|high)$")
+    rationale: str = Field(..., min_length=10, max_length=500)
+
+
+class PlanCreateRequest(BaseModel):
+    workspace_id: str = Field(..., min_length=3, max_length=80)
+    title: str = Field(..., min_length=3, max_length=120)
+    objective: str = Field(..., min_length=10, max_length=500)
+    tasks: List[PlanTaskInput] = Field(..., min_length=1, max_length=25)
+
+
+class PlanCreateResponse(BaseModel):
+    plan_id: str
+    status: str
+
+
+class RunTask(BaseModel):
+    id: str
+    title: str
+    phase: str
+    risk_level: str
+    status: str
+    rationale: str
+
+
+class WorkflowRunResponse(BaseModel):
+    run_id: str
+    plan_id: str
+    status: str
+    tasks: List[RunTask]
+    audit_events: List[dict]
+
+
+class ApprovalRequest(BaseModel):
+    task_id: str = Field(..., min_length=3)
+    decision: str = Field(..., pattern=r"^(approve|reject)$")
+    reason: str = Field(..., min_length=5, max_length=400)

--- a/app/services/workflow_service.py
+++ b/app/services/workflow_service.py
@@ -1,0 +1,173 @@
+"""In-memory orchestration/training workflow service for MVP simulation."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from threading import Lock
+from typing import Any, Dict, List, Literal
+from uuid import uuid4
+
+TaskStatus = Literal["pending", "running", "pending_approval", "succeeded", "failed"]
+RunStatus = Literal["draft", "running", "pending_approval", "succeeded", "failed"]
+Decision = Literal["approve", "reject"]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class TaskRecord:
+    id: str
+    title: str
+    phase: str
+    risk_level: str
+    status: TaskStatus = "pending"
+    rationale: str = ""
+
+
+@dataclass
+class PlanRecord:
+    id: str
+    workspace_id: str
+    title: str
+    objective: str
+    tasks: List[TaskRecord]
+    created_at: str = field(default_factory=_utc_now)
+
+
+@dataclass
+class RunRecord:
+    id: str
+    plan_id: str
+    status: RunStatus
+    tasks: List[TaskRecord]
+    audit_events: List[Dict[str, Any]]
+    created_at: str = field(default_factory=_utc_now)
+    updated_at: str = field(default_factory=_utc_now)
+
+
+class WorkflowService:
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._plans: Dict[str, PlanRecord] = {}
+        self._runs: Dict[str, RunRecord] = {}
+
+    def create_plan(self, workspace_id: str, title: str, objective: str, tasks: List[Dict[str, str]]) -> PlanRecord:
+        plan_id = str(uuid4())
+        normalized_tasks = [
+            TaskRecord(
+                id=str(uuid4()),
+                title=item["title"],
+                phase=item["phase"],
+                risk_level=item["risk_level"],
+                rationale=item["rationale"],
+            )
+            for item in tasks
+        ]
+        plan = PlanRecord(
+            id=plan_id,
+            workspace_id=workspace_id,
+            title=title,
+            objective=objective,
+            tasks=normalized_tasks,
+        )
+        with self._lock:
+            self._plans[plan_id] = plan
+        return plan
+
+    def execute_plan(self, plan_id: str) -> RunRecord:
+        with self._lock:
+            plan = self._plans.get(plan_id)
+            if not plan:
+                raise KeyError("plan_not_found")
+
+            run_id = str(uuid4())
+            tasks = [
+                TaskRecord(
+                    id=t.id,
+                    title=t.title,
+                    phase=t.phase,
+                    risk_level=t.risk_level,
+                    status="pending",
+                    rationale=t.rationale,
+                )
+                for t in plan.tasks
+            ]
+            run = RunRecord(id=run_id, plan_id=plan_id, status="running", tasks=tasks, audit_events=[])
+            self._runs[run_id] = run
+            self._append_event(run, "run_created", {"plan_id": plan_id})
+            self._progress_run_locked(run)
+            return run
+
+    def get_run(self, run_id: str) -> RunRecord:
+        with self._lock:
+            run = self._runs.get(run_id)
+            if not run:
+                raise KeyError("run_not_found")
+            return run
+
+    def submit_approval(self, run_id: str, task_id: str, decision: Decision, reason: str) -> RunRecord:
+        with self._lock:
+            run = self._runs.get(run_id)
+            if not run:
+                raise KeyError("run_not_found")
+
+            target = next((task for task in run.tasks if task.id == task_id), None)
+            if not target:
+                raise KeyError("task_not_found")
+            if target.status != "pending_approval":
+                raise ValueError("task_not_waiting_approval")
+
+            self._append_event(
+                run,
+                "approval_decision",
+                {"task_id": task_id, "decision": decision, "reason": reason},
+            )
+            if decision == "reject":
+                target.status = "failed"
+                run.status = "failed"
+                run.updated_at = _utc_now()
+                self._append_event(run, "run_failed", {"task_id": task_id, "reason": reason})
+                return run
+
+            target.status = "succeeded"
+            run.status = "running"
+            run.updated_at = _utc_now()
+            self._append_event(run, "task_resumed", {"task_id": task_id})
+            self._progress_run_locked(run)
+            return run
+
+    def _progress_run_locked(self, run: RunRecord) -> None:
+        for task in run.tasks:
+            if task.status in {"succeeded", "failed"}:
+                continue
+
+            task.status = "running"
+            self._append_event(run, "task_started", {"task_id": task.id, "title": task.title})
+            if task.risk_level == "high":
+                task.status = "pending_approval"
+                run.status = "pending_approval"
+                run.updated_at = _utc_now()
+                self._append_event(run, "approval_required", {"task_id": task.id, "phase": task.phase})
+                return
+
+            task.status = "succeeded"
+            self._append_event(run, "task_succeeded", {"task_id": task.id, "phase": task.phase})
+
+        run.status = "succeeded"
+        run.updated_at = _utc_now()
+        self._append_event(run, "run_succeeded", {"run_id": run.id})
+
+    def _append_event(self, run: RunRecord, event_type: str, payload: Dict[str, Any]) -> None:
+        run.audit_events.append(
+            {
+                "event_id": str(uuid4()),
+                "event_type": event_type,
+                "timestamp": _utc_now(),
+                "payload": payload,
+            }
+        )
+
+
+workflow_service = WorkflowService()

--- a/docs/architecture-draft.md
+++ b/docs/architecture-draft.md
@@ -1,0 +1,290 @@
+# Architecture Design Draft (Phase 3 / MVP)
+
+## 1) System Context Diagram
+
+```mermaid
+flowchart LR
+  learner[Learner / Practitioner]
+  approver[Approver / Admin]
+  web[Web App\nReact + TypeScript]
+  api[Control Plane API\nFastAPI]
+  orchestrator[Orchestration Core\nPlanner + Graph Builder + Router]
+  workers[Execution Runtime\nQueue Workers]
+  agents[Agent Adapter Layer\nExisting DevOps Agents]
+  pg[(Postgres)]
+  redis[(Redis)]
+  object[(Object Storage)]
+  llm[LLM Provider API]
+  git[Git Provider API]
+  registry[Container Registry]
+  ci[CI Provider API]
+  metrics[Prometheus / Logs / Traces]
+
+  learner --> web
+  approver --> web
+  web --> api
+  api --> orchestrator
+  orchestrator --> workers
+  workers --> agents
+  agents --> llm
+  agents --> git
+  agents --> ci
+  agents --> registry
+
+  api --> pg
+  orchestrator --> pg
+  workers --> pg
+  api --> redis
+  orchestrator --> redis
+  workers --> object
+
+  api --> metrics
+  orchestrator --> metrics
+  workers --> metrics
+```
+
+### Boundary
+- **Inside boundary:** Web App, Control Plane API, Orchestration Core, Workers, Agent Adapters, Postgres, Redis, Object Storage.
+- **Outside boundary:** LLM provider, Git providers, CI providers, container registries, human actors.
+
+## 2) Component Architecture
+
+### 2.1 API Layer (FastAPI)
+- AuthN/AuthZ (JWT + RBAC).
+- Intake APIs (project input, transcript upload metadata).
+- Plan APIs (create/edit/confirm plan).
+- Execution APIs (start/stop/resume workflow).
+- Approval APIs (queue, approve/reject/request changes).
+- Audit/Timeline APIs (event stream, rationale replay).
+
+### 2.2 Orchestration Core
+- **Planner:** transforms intake into structured task intents.
+- **Graph Builder:** creates DAG, validates acyclic dependencies.
+- **Policy Engine:** evaluates risk + decides approval gates.
+- **Router:** maps capability requirements to agent registry entries.
+- **Executor Controller:** dispatches jobs to queue runtime and manages state transitions.
+
+### 2.3 Execution Runtime
+- Queue-backed workers process `TaskNode` jobs.
+- Enforces idempotency key checks before side effects.
+- Applies retry + exponential backoff + circuit breaker policy.
+- Emits normalized domain events to audit stream.
+
+### 2.4 Storage Layer
+- **Postgres:** source of truth (plans, nodes, approvals, audit events, progress).
+- **Redis:** queue backend, distributed locks, rate counters, cache.
+- **Object Storage:** large artifacts (logs, generated files, transcript chunks).
+
+### 2.5 Knowledge/Context Retrieval
+- Pulls prior workspace artifacts, run history, and selected templates.
+- Retrieves curated training rationale snippets for explainability.
+- Uses deterministic template-first prompts before LLM expansion.
+
+## 3) Data Model Sketch
+
+### Core Entities
+- **Workspace:** tenant boundary and policy defaults.
+- **Plan:** user-approved execution plan linked to workspace.
+- **TaskNode:** executable unit with status/retry/idempotency controls.
+- **TaskEdge:** dependency graph relation between task nodes.
+- **AgentRegistryEntry:** capability + version + contract schemas.
+- **AgentRun:** execution record for a task attempt.
+- **ApprovalGate / ApprovalDecision:** policy hold and human decision trail.
+- **AuditEvent:** append-only immutable event stream.
+- **LearningModule / ModuleProgress:** training content + learner progression.
+
+### Key Relationships
+- Workspace 1..N Plans
+- Plan 1..N TaskNodes
+- TaskNodes N..N via TaskEdges
+- TaskNode 1..N AgentRuns
+- TaskNode 0..1 ApprovalGate
+- ApprovalGate 1..N ApprovalDecisions
+- Workspace 1..N AuditEvents
+
+## 4) Sequence Diagrams (Critical Flows)
+
+### 4.1 Transcript -> Plan -> Execution
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant W as Web App
+  participant A as API
+  participant O as Orchestrator
+  participant Q as Queue Worker
+  participant G as Agent Adapter
+  participant DB as Postgres
+
+  U->>W: Submit transcript + objective
+  W->>A: POST /intake
+  A->>O: normalize + request plan
+  O->>O: build DAG + validate no cycles
+  O->>DB: persist Plan + TaskNodes
+  A-->>W: plan draft
+  U->>W: confirm plan
+  W->>A: POST /plans/{id}/execute
+  A->>O: start workflow
+  O->>Q: enqueue READY nodes
+  Q->>G: execute task
+  G-->>Q: normalized result
+  Q->>DB: persist AgentRun + AuditEvent
+  Q->>O: emit task completion
+  O-->>A: workflow state update
+  A-->>W: timeline update
+```
+
+### 4.2 Approval Gate Workflow
+```mermaid
+sequenceDiagram
+  participant Q as Queue Worker
+  participant O as Orchestrator
+  participant P as Policy Engine
+  participant A as API
+  participant R as Approver
+  participant DB as Postgres
+
+  Q->>P: evaluate risk for task
+  P-->>Q: gate required
+  Q->>O: set task PENDING_APPROVAL
+  O->>DB: create ApprovalGate + AuditEvent
+  A-->>R: show pending approval queue
+  R->>A: approve/reject + reason
+  A->>DB: persist ApprovalDecision
+  A->>O: resume or fail branch
+  O->>Q: continue execution or terminate path
+```
+
+### 4.3 Agent Execution with Retry/Failure
+```mermaid
+sequenceDiagram
+  participant O as Orchestrator
+  participant Q as Queue Worker
+  participant G as Agent Adapter
+  participant DB as Postgres
+
+  O->>Q: dispatch task with idempotency_key
+  Q->>G: execute(payload)
+  alt success
+    G-->>Q: result
+    Q->>DB: mark SUCCEEDED + AuditEvent
+  else retryable failure
+    G-->>Q: transient error
+    Q->>DB: mark RETRY_WAIT + retry_count++
+    Q->>O: reschedule with backoff
+  else non-retryable failure
+    G-->>Q: fatal error
+    Q->>DB: mark FAILED + error_code
+    Q->>DB: persist diagnostics/audit
+  end
+```
+
+### 4.4 Audit Event Capture
+```mermaid
+sequenceDiagram
+  participant S as Service(API/Orchestrator/Worker)
+  participant E as Event Normalizer
+  participant DB as Postgres
+  participant UI as Timeline UI
+
+  S->>E: domain event payload
+  E->>DB: append AuditEvent
+  UI->>DB: fetch events by plan/workspace
+  DB-->>UI: ordered immutable timeline
+```
+
+## 5) Failure Mode Matrix
+
+| Scenario | Detection | Immediate Handling | Recovery Path | Audit Requirement |
+|---|---|---|---|---|
+| LLM garbage output | Output schema validation fails | Mark `FAILED_VALIDATION`; block side effects | Retry with stricter template, then require human edit | Store prompt hash, output hash, validation errors |
+| Agent crash mid-execution | Worker timeout/process exit | Set `RETRY_WAIT` if retry budget remains | Resume via idempotency key; otherwise manual intervention task | Persist crash signature + retry timeline |
+| Large transcript upload | Request size threshold / streaming guard | Return 413 with chunk-upload path | Multipart/chunked upload + async preprocess job | Record rejected payload metadata + actor |
+| Dependency loop in graph | DAG validation during plan build | Reject plan before execution | Planner regeneration with cycle diagnostics | Persist cycle diagnostics in audit |
+| External API outage | Circuit breaker open + health checks | Fast-fail retryable tasks | Cooldown + backoff + fallback provider/manual path | Persist outage window + affected nodes |
+| Approval timeout | SLA timer breach on gate | Keep workflow paused; escalate | Notify backup approver or policy auto-cancel | Persist escalation + timeout reason |
+
+## 6) Agent Registry + Migration Strategy
+
+### Existing Agents
+- `build_predictor_agent`
+- `code_review_agent`
+- `github_actions_agent`
+- `dockerfile_agent`
+- `build_status_agent`
+- `chat_agent`
+
+### Adapter Contract
+Each agent wrapped behind:
+- `validate_input(payload) -> ValidatedPayload`
+- `execute(payload, context) -> RawResult`
+- `validate_output(result) -> NormalizedResult`
+- `classify_error(error) -> retryable|fatal`
+
+### Migration Plan
+1. Introduce registry table with capability/version/schema fields.
+2. Build adapters incrementally; keep existing endpoint paths intact.
+3. Route new orchestration flows via adapters while legacy direct calls remain supported.
+4. Add contract tests + canary rollout by capability flag.
+5. Remove legacy direct coupling after parity metrics pass.
+
+### Backward Compatibility
+- Preserve existing route payloads/responses.
+- Version contracts (`v1`, `v2`) in registry metadata.
+- Maintain dual-path execution during transition window.
+
+## 7) Technology Stack Decision Record (ADR Summary)
+
+### ADR-001: FastAPI for Control Plane
+- **Decision:** FastAPI.
+- **Why:** Typed contracts (Pydantic), async I/O, strong testability, existing project alignment.
+- **Rejected alternatives:** Flask (less typed by default), Django (heavier for control plane).
+
+### ADR-002: Postgres as System of Record
+- **Decision:** Postgres.
+- **Why:** transactional consistency for plan/task/approval states, mature indexing/querying.
+- **Rejected alternatives:** NoSQL-first stores (weaker relational guarantees for DAG/approval joins).
+
+### ADR-003: Redis for Queue + Cache
+- **Decision:** Redis.
+- **Why:** low-latency queue backend, distributed locks, rate counters, simple ops footprint.
+- **Rejected alternatives:** DB-backed queue (higher contention/latency).
+
+### ADR-004: Queue Runtime Choice (Celery over Temporal for MVP)
+- **Decision:** Celery + Redis for MVP.
+- **Why:** fast adoption, Python-native ecosystem, low setup overhead, sufficient for bounded workflows.
+- **Deferred:** Temporal for post-MVP if long-running/high-compensation workflows outgrow Celery semantics.
+
+### ADR-005: Frontend Framework
+- **Decision:** React + TypeScript + Vite.
+- **Why:** already present in repo, rapid UI iteration, strong DX/testing support.
+
+## 8) Security, Performance, Observability Baselines
+
+### Security
+- JWT short-lived access + refresh rotation.
+- RBAC (`learner`, `practitioner`, `approver`, `admin`).
+- Strict input validation at all boundaries.
+- Per-workspace quotas and rate limits.
+- Append-only audit writes.
+
+### Performance
+- API p95 target <200ms for non-LLM endpoints.
+- DB p95 target <100ms on indexed reads.
+- Recommended indexes:
+  - `task_nodes(plan_id, status)`
+  - `approval_gates(status, requested_at)`
+  - `audit_events(workspace_id, occurred_at)`
+
+### Observability
+- Structured logs with `request_id`, `workspace_id`, `plan_id`, `task_id`.
+- Metrics: latency, success/failure rate, queue depth, retries, approval backlog, token spend.
+- Endpoints: `/healthz`, `/readyz`, `/metrics`.
+
+## 9) Implementation Sequence
+1. Add schema/migrations for plan graph, approvals, audit, registry.
+2. Build orchestration core (planner + graph validator + router + executor controller).
+3. Integrate Celery worker runtime and idempotent execution guards.
+4. Migrate existing agents through adapter contracts + canary flags.
+5. Implement approval APIs/UI queue and pause/resume semantics.
+6. Add rationale event replay APIs for training mode.
+7. Harden with integration tests, load checks, and security scanning gates.

--- a/docs/product-definition-prd.md
+++ b/docs/product-definition-prd.md
@@ -1,0 +1,167 @@
+# Product Definition (Brief + PRD)
+
+## 1) Objective
+Build a production-grade web application that trains new DevOps learners on the complete software delivery lifecycle while enabling practitioners to execute guided, controlled DevOps automation.
+
+The product must ship a reliable MVP first, with safety and approval gates as core constraints.
+
+## 2) Problem Statement
+New engineers struggle to connect theory to real software delivery. Existing tutorials are either:
+- Too shallow (slides-only, no execution context), or
+- Too operationally risky (unbounded automation with weak guardrails).
+
+Teams need one system that teaches **and** demonstrates practical workflow execution from intake to release operations.
+
+## 3) Personas
+- **Learner (Primary):** New DevOps or software engineer learning end-to-end lifecycle.
+- **Practitioner (Primary):** DevOps engineer wanting assisted task orchestration with controls.
+- **Reviewer/Approver (Secondary):** Senior engineer approving high-risk actions.
+- **Admin (Secondary):** Maintains learning paths, modules, and governance settings.
+
+## 4) Product Goals
+- Deliver an MVP that provides lifecycle-aligned tutorials and controlled task orchestration.
+- Support high reliability through deterministic workflows, idempotent operations, and auditable state.
+- Ensure safety with explicit approval gates for risky actions.
+- Keep training mode practical by exposing structured "decision rationale" tied to actual agent actions.
+
+## 5) Non-Goals (MVP)
+- No unrestricted direct production mutation.
+- No fully autonomous cloud provisioning without mandatory human approval.
+- No advanced visual simulation engine in MVP (deferred post-MVP).
+- No broad multi-cloud IaC orchestration beyond curated, bounded scenarios.
+
+## 6) Scope (MVP)
+
+### In Scope
+1. **Lifecycle Training Content**
+   - Module-based tutorials mapped to SDLC/DevOps phases.
+   - Step-by-step guidance with quiz checkpoints.
+   - Structured decision logs explaining why specific actions are recommended.
+
+2. **Controlled Orchestration**
+   - Intake of project context and requirements.
+   - Generated execution plan (task graph) with statuses.
+   - Existing agents invoked via registry with contract validation.
+
+3. **Approval Gates (Core Safety Feature)**
+   - Rule-driven gate policy (e.g., deploy, infra change, secrets-sensitive actions).
+   - Human approver workflow with approve/reject and reason capture.
+   - Full audit trail per gate decision.
+
+4. **Observability + Reliability**
+   - /healthz, /readyz, metrics endpoint.
+   - Structured logs with request correlation.
+   - Retry/circuit-breaker strategy for external calls.
+
+5. **Progress + Governance**
+   - Learner progress tracking and completion.
+   - Run history, artifacts, and approvals timeline.
+
+### Deferred (Post-MVP)
+- Rich visual lifecycle explorer with animations and interactive map.
+- Sandbox ephemeral environments per learner.
+- Advanced autonomous optimization loops.
+
+## 7) Functional Requirements
+
+### FR-1 Intake & Planning
+- System accepts project goals, constraints, and optional repository context.
+- System generates a task graph with explicit dependencies and estimated execution steps.
+- User can edit/confirm plan before execution.
+
+### FR-2 Agent Orchestration
+- Orchestrator executes task nodes against registered agents.
+- Agent responses validated against typed contracts.
+- Task retries follow policy with bounded attempts and exponential backoff.
+
+### FR-3 Training Mode (MVP form)
+- Each orchestration step emits rationale log entries:
+  - input considered,
+  - decision made,
+  - expected outcome,
+  - fallback guidance.
+- User can replay execution timeline for learning.
+
+### FR-4 Approval Gate UX
+- Risk-scored actions create `PENDING_APPROVAL` checkpoints.
+- Approver receives in-app notification queue (MVP baseline).
+- Approval form captures decision + reason + optional override notes.
+- Rejection routes workflow to corrective branch with actionable feedback.
+
+### FR-5 Auditability
+- Immutable append-only event log for:
+  - plan creation,
+  - task start/end,
+  - approvals,
+  - failures/retries,
+  - artifacts produced.
+
+### FR-6 Learner Experience
+- Tutorial module player with objectives, prerequisites, and checkpoints.
+- Quiz attempts with score and explanation.
+- Dashboard with completion and recommended next module.
+
+## 8) Non-Functional Requirements
+- API p95 latency target: <200ms for non-LLM standard endpoints.
+- DB p95 latency target: <100ms for indexed reads in normal load.
+- Test coverage target: >=80% for backend core domain and orchestration logic.
+- Security baseline: authentication, RBAC, input validation, rate limiting, safe CORS defaults.
+- Reliability SLO target for core API availability: 99.9% (excluding external LLM outages).
+
+## 9) Approval Gate UX (MVP)
+- **Trigger:** policy engine marks task as high-risk.
+- **State transition:** `RUNNING -> PENDING_APPROVAL`.
+- **Approver dashboard:** shows pending items, risk reason, diff/impact summary.
+- **Actions:** approve, reject, request changes.
+- **On approve:** resume from paused node.
+- **On reject:** mark node failed with required remediation note.
+- **Audit:** record actor, timestamp, decision payload.
+
+## 10) Cost Model (Initial)
+Assumptions for early MVP pilot:
+- 100 monthly active learners.
+- 20 orchestration runs/day average.
+- Mixed LLM + deterministic execution.
+
+Cost buckets:
+- **LLM API:** primary variable cost; enforce token budgets and caching.
+- **Compute:** API + worker pods (autoscaled baseline low).
+- **Storage:** Postgres + object storage for artifacts/log exports.
+- **Observability:** metrics/log retention.
+
+Cost controls:
+- Prompt/response truncation policies.
+- Reuse deterministic templates before LLM calls.
+- Cache repeated planning outputs for similar prompts.
+- Hard per-workspace token quota and rate controls.
+
+## 11) Delivery Plan (Adjusted)
+Timeline assumes part-time execution with quality gates.
+
+- **Phase A: Product Definition (1-2 weeks)**
+  - Finalize this merged Brief + PRD.
+  - Acceptance criteria and event taxonomy.
+
+- **Phase B: Architecture + Contracts (2 weeks)**
+  - Data model, agent registry contracts, failure matrix.
+  - Integration design for existing agents.
+
+- **Phase C: MVP Build (3-5 weeks)**
+  - Intake, planning, orchestration, approval gates, training rationale logs.
+
+- **Phase D: Hardening + Release (2-3 weeks)**
+  - Security, test stabilization, performance, observability, release playbook.
+
+**Total:** 8-12 weeks for MVP.
+
+## 12) Acceptance Criteria (MVP)
+- A learner can complete at least 5 lifecycle modules end-to-end.
+- A practitioner can run a curated project workflow with at least one approval gate.
+- Every orchestration run has complete audit trail and replayable rationale logs.
+- Existing core agents are integrated via registry contracts and pass integration tests.
+- CI enforces lint, tests, build, and security scan gates.
+
+## 13) Open Decisions for Review
+- Final set of risk rules for mandatory approvals.
+- RBAC granularity for approver roles (team-level vs workspace-level).
+- Artifact retention window and compliance requirements.

--- a/tests/test_training_api.py
+++ b/tests/test_training_api.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def _make_plan(client: TestClient) -> str:
+    payload = {
+        "workspace_id": "ws-devops",
+        "title": "Ship Inventory API Safely",
+        "objective": "Plan and execute a safe release with approvals and observability.",
+        "tasks": [
+            {
+                "title": "Design deployment strategy",
+                "phase": "Plan",
+                "risk_level": "low",
+                "rationale": "Baseline deployment strategy aligns rollout and rollback constraints.",
+            },
+            {
+                "title": "Production deploy",
+                "phase": "CI/CD",
+                "risk_level": "high",
+                "rationale": "Production changes require approval to enforce least-risk release controls.",
+            },
+        ],
+    }
+    resp = client.post("/training/plans", json=payload)
+    assert resp.status_code == 201
+    return resp.json()["plan_id"]
+
+
+def test_lifecycle_and_modules_endpoints() -> None:
+    client = TestClient(app)
+
+    lifecycle = client.get("/training/lifecycle")
+    assert lifecycle.status_code == 200
+    assert len(lifecycle.json()) >= 5
+
+    modules = client.get("/training/modules")
+    assert modules.status_code == 200
+    assert len(modules.json()) >= 3
+
+
+def test_plan_execution_requires_approval_then_completes() -> None:
+    client = TestClient(app)
+    plan_id = _make_plan(client)
+
+    run_resp = client.post(f"/training/plans/{plan_id}/execute")
+    assert run_resp.status_code == 200
+    run_data = run_resp.json()
+    assert run_data["status"] == "pending_approval"
+
+    pending_task = next(task for task in run_data["tasks"] if task["status"] == "pending_approval")
+
+    approve_resp = client.post(
+        f"/training/runs/{run_data['run_id']}/approval",
+        json={"task_id": pending_task["id"], "decision": "approve", "reason": "Validated canary checks"},
+    )
+    assert approve_resp.status_code == 200
+    approved_data = approve_resp.json()
+    assert approved_data["status"] == "succeeded"
+
+
+def test_approval_reject_marks_run_failed() -> None:
+    client = TestClient(app)
+    plan_id = _make_plan(client)
+
+    run_resp = client.post(f"/training/plans/{plan_id}/execute")
+    run_data = run_resp.json()
+    pending_task = next(task for task in run_data["tasks"] if task["status"] == "pending_approval")
+
+    reject_resp = client.post(
+        f"/training/runs/{run_data['run_id']}/approval",
+        json={"task_id": pending_task["id"], "decision": "reject", "reason": "Failed pre-deploy checks"},
+    )
+    assert reject_resp.status_code == 200
+    assert reject_resp.json()["status"] == "failed"


### PR DESCRIPTION
### Motivation
- Provide a safe, approval-gated training/workflow simulation surface so learners and practitioners can create, execute, and review orchestration runs without touching production systems. 
- Capture a minimal in-memory orchestration core to exercise approval gates, audit timelines, and state transitions for Phase 3 planning and early integration tests. 
- Ship architecture and product-definition docs to align implementation and review cycles for the orchestrator/approval UX. 
- Fix PR metadata flow by adding a repository PR template so automated PR updates no longer fall back to placeholder content. 

### Description
- Added training HTTP surface and wiring: `app/routers/training.py` and registered it in `app/main.py` via `app.include_router(training_router)`. 
- Introduced typed domain models and request/response schemas in `app/schemas.py` for lifecycle, modules, plan creation, run/task shapes, and approval requests. 
- Implemented an in-memory orchestration service `app/services/workflow_service.py` implementing plan creation, run execution, pending-approval gating, approval resolution (approve/reject), and append-only audit events. 
- Added integration-style unit tests in `tests/test_training_api.py` to validate lifecycle/modules endpoints, plan execution pause/approval flows, and reject->fail behavior. 
- Documentation and repo hygiene: `docs/architecture-draft.md`, `docs/product-definition-prd.md`, `README.md` updates to reference training APIs, and `.github/pull_request_template.md` to enforce PR metadata. 

### Testing
- Added unit/integration tests at `tests/test_training_api.py` covering lifecycle/modules listing, plan creation + execution, approve flow, and reject flow. 
- No automated test suite was executed as part of this commit; run the new tests with `pytest -q` locally or via CI. 
- Repository history indicates prior training tests passed in the earlier implementation series, but this change only adds the PR-template + feature code and did not run CI in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd93f38c88331b9a2f0d838354a9e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Training orchestration API with endpoints for creating and executing training plans, managing workflow runs, and handling task approvals
  * Environment variables configuration support

* **Documentation**
  * Updated README with planning documents, system requirements, environment variables reference, and training API endpoint specifications
  * Added comprehensive architecture design and product definition documents
  * Introduced pull request template for contributor guidance

* **Tests**
  * Added test suite for training API endpoints and workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->